### PR TITLE
Move content to front-end client README/wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,43 @@
 # All the (Linotype) Matrices v0.2
 
-## Essential references
-* [plan for development]
-* [user stories](https://github.com/EricLScace/allthemats-ember/wiki/user-stories)
+## Index
+* Checklists:
+<br>[Embler CLI installation](https://github.com/EricLScace/allthemats-ember/wiki/cklist-ember-cli-install.md)
+<br>
+[Ember template installation](https://github.com/EricLScace/allthemats-ember/wiki/cklist-ember-install)
+<br>
+[Repository management](https://github.com/EricLScace/allthemats-ember/wiki/cklist-repo-management)
+
+* [Development plan](https://github.com/EricLScace/allthemats-ember/wiki/schedule.md)
+
+* Licenses:
+<br>[Creative Commons](https://github.com/EricLScace/allthemats-ember/wiki/license-creative-commons)
+<br>[General Assembly](https://github.com/EricLScace/allthemats-ember/wiki/license-ga)
+<br>[GNU](https://github.com/EricLScace/allthemats-ember/wiki/license-gnu)
+<br>[MIT](https://github.com/EricLScace/allthemats-ember/wiki/license-mit)
+
+* References:
+<br>[GA capstone project requirements](https://github.com/ga-wdi-boston/capstone-project) applies to v0.2
+<br>[GA full stack project requirements](https://git.generalassemb.ly/ga-wdi-boston/full-stack-project) applies to v0.1
+<br>[GA full stack project presentation requirements](https://github.com/ga-wdi-boston/full-stack-project-practice) applies to v0.1
+<br>[Linotype: The Film — trailer](https://www.youtube.com/watch?v=avDuKuBNuCk)
+<br>[Linotype matrix identification publications](http://www.circuitousroot.com/artifice/letters/press/compline/typography/matrix/mergenthaler/)
+
+* Wireframes
+
+* [User stories](https://github.com/EricLScace/allthemats-ember/wiki/user-stories)
 
 ## Changes from v0.1
 * Ember client
 * Database of matrices expanded from the v0.1 test set of 40 matrices to the full 2,907 matrix listing previously compiled by Linotype staff.
 * User stories expanded: user can search not only for a specific Linotype matrix code, but also for all matrices that meet search criteria; e.g., Helvetica bold in 8 pt to 10 pt sizes.
-* ERD changed to optimize size of database, and to accommodate more edge cases in the description and use of Linotype matrices.
+* ERD changed to optimize size of database, and to accommodate more edge cases in the description and use of Linotype matrices.git
+
+## Contributors:
+Eric Scace wrote all the documentation and code.
+
+## Licenses:
+1. All content is licensed under a [CC­BY­NC­SA 4.0 license](creative-commons).
+1. All software code is licensed under [GNU GPLv3](gnu).
+2. See also [General Assembly](GA) and [MIT](MIT) license terms.
+2. For commercial use or alternative licensing, please contact legal@ga.co.


### PR DESCRIPTION
Why:
* Some relevant content was placed in back-end wiki for v0.1
* Content provides background for future contributors/reviewers

What:
* new text in README client side
* links to additional pages in client side wiki

Editorials: n/a

Test results: n/a

Consequences: n/a

Close #5