### PR TITLE
Fix gap between text & top/side border

### DIFF
--- a/app/styles/composition.scss
+++ b/app/styles/composition.scss
@@ -7,18 +7,11 @@
 
 body {
   background-color: $gray;
-  box-sizing: border-box;
   font-family: $font-family;
   font-size: $font-size;
   font-style: $font-style;
   font-weight: $font-weight;
   line-height: $line-height;
-  // Must override the .container-fluid values for left & right padding
-  margin-left: 0 !important;
-  padding-left: 0 !important;
-  padding-right: 0 !important;
-  padding-top: 10;
-
 }
 
 .app-title {
@@ -35,11 +28,16 @@ body {
   border-radius: $border-radius;
   box-shadow: $box-shadow;
   min-height: $min-height-row-0;
+  padding: $padding;
 }
 
 .test-box {
   border: $border-test;
   border-radius: $border-radius;
+  min-height: $min-height-row-0;
+  padding-left: $padding;
+  padding-right: $padding;
+  padding-top: $padding;
 }
 
 // .announcement {

--- a/app/styles/shapes.scss
+++ b/app/styles/shapes.scss
@@ -3,6 +3,6 @@
 
 $border-radius: 8px;
 $border-test: 1px dashed;
-$box-shadow: 2px 2px 4px $black;
+$box-shadow: ($font-size / 6) ($font-size / 6) ($font-size / 3) $black;
 $min-height-row-0: 3 * $font-size;
-$padding: 0;
+$padding: $font-size / 3;

--- a/app/styles/typography.scss
+++ b/app/styles/typography.scss
@@ -1,6 +1,7 @@
 $font-family:     botanika-web, sans-serif;
 $font-size:       18px;   // foundation font size
-$font-size-title: 2 * $font-size;
+$line-height:     1.2;
+
+$font-size-title: (1 + $line-height) * $font-size;
 $font-style:      normal;
 $font-weight:     400;
-$line-height:     1.2;

--- a/app/templates/components/row-0.hbs
+++ b/app/templates/components/row-0.hbs
@@ -5,12 +5,16 @@
   {{!-- Top-left corner: choose type of search --}}
   {{!-- Fixed-width container --}}
   <div class="input-box container col-sm-2 height-row-0">
-    Search selector goes here
+    <span>
+      Search selector goes here
+    </span>
   </div>
 
   {{!-- Fixed-width container: matrix image--}}
   <div class="test-box container col-sm-2 height-row-0">
-    Matrix image goes here
+    <span>
+      Matrix image goes here
+    </span>
   </div>
 
   {{!-- Fixed-width container: app title --}}


### PR DESCRIPTION
Why: Comply with UI design spec

What:
* Padding & margin don't work. Both add space outside the border.
* Needed to place containter contents in a <span>.

Test results: ok

Editorials: n/a

Consequences: none

Reference #42 import Ember auth code
Close #44 import font
Close #51 typographical style structure <-- working
Close #52 fix gap between text & left/top of border